### PR TITLE
fix: rename entry-stream to blockstream

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -5,7 +5,7 @@ export default {
     unixds: true,
     host: '127.0.0.1',
     port: 7654,
-    socket: '/tmp/solana-entry-stream.sock',
+    socket: '/tmp/solana-blockstream.sock',
   },
   redis: {
     host: '127.0.0.1',


### PR DESCRIPTION
Required by solana-labs/solana#2857 for testnet deployment