### PR TITLE
Update entry.id to entry.hash

### DIFF
--- a/api/inbound-stream.js
+++ b/api/inbound-stream.js
@@ -31,7 +31,7 @@ class BridgeFn {
       outMessage.h = inMessage.h;
       outMessage.s = inMessage.s;
       outMessage.l = inMessage.l;
-      outMessage.id = b58e(inMessage.entry.id);
+      outMessage.id = b58e(inMessage.entry.hash);
 
       outMessage.transactions = _.map(inMessage.entry.transactions, x => {
         let txn = Transaction.from(Buffer.from(x));


### PR DESCRIPTION
To catch up with solana core, need to update entry.id to entry.hash, renamed here: https://github.com/solana-labs/solana/commit/7c4473e0aabcd4e781f092146f1d7ec2967ace33