### PR TITLE
fix: add babel-plugin-transform-runtime to resolve api server start failure

### DIFF
--- a/bin/blockexplorer.sh
+++ b/bin/blockexplorer.sh
@@ -43,10 +43,10 @@ trap cleanup SIGINT SIGTERM ERR
 set -x
 redis-cli ping
 
-node build/api/api.js 2>&1 | tee "$cwd"/solana-blockexplorer-api.log &
+npm run start-prod:api 2>&1 | tee "$cwd"/solana-blockexplorer-api.log &
 api=$!
 
-npm run serve:ui 2>&1 | tee "$cwd"/solana-blockexplorer-ui.log &
+npm run start-prod:ui 2>&1 | tee "$cwd"/solana-blockexplorer-ui.log &
 ui=$!
 
 wait "$ui"

--- a/bin/blockexplorer.sh
+++ b/bin/blockexplorer.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+cwd=$PWD
+
 rootDir=$(
   cd "$(dirname "$0")";
   node -p '
@@ -26,7 +28,7 @@ rootDir=$(
 cd "$rootDir"
 
 if [[ ! -d build || ! -f build/api/api.js ]]; then
-  echo "Error: build/ artifacts missing"
+  echo "Error: build/ artifacts missing.  Run |yarn run build| to create them"
   exit 1
 fi
 
@@ -41,10 +43,10 @@ trap cleanup SIGINT SIGTERM ERR
 set -x
 redis-cli ping
 
-node build/api/api.js &
+node build/api/api.js 2>&1 | tee "$cwd"/solana-blockexplorer-api.log &
 api=$!
 
-npm run serve:ui &
+npm run serve:ui 2>&1 | tee "$cwd"/solana-blockexplorer-ui.log &
 ui=$!
 
 wait "$ui"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^0.14.16",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "base-58": "^0.0.1",
     "cors": "^2.8.5",
     "express": "^4.16.4",
@@ -56,7 +57,7 @@
   },
   "scripts": {
     "build": "set -ex; npm run build:ui; npm run build:api",
-    "build:api": "babel --presets env api/* -d build",
+    "build:api": "babel --presets env --plugins transform-runtime api/* -d build",
     "build:ui": "react-scripts build",
     "lint": "set -ex; npm run pretty; eslint .",
     "lint:fix": "npm run lint -- --fix",
@@ -66,7 +67,8 @@
     "re": "semantic-release --repository-url git@github.com:solana-labs/blockexplorer.git",
     "start:api": "set -ex; redis-cli ping; babel-node --presets env api/api.js",
     "start:ui": "react-scripts start",
-    "serve:ui": "serve -s build",
+    "start-prod:api": " node build/api/api.js",
+    "start-prod:ui": "serve -s build",
     "test:ui": "react-scripts test"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,6 +2362,13 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
When we started using `await` in api.js, we inadvertently added a dependency on `babel-plugin-transform-runtime` that is only visible in the deployed blockexplorer since we use `babel-node` in development