### PR TITLE
fix: hack up .env.production to avoid breaking production builds

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_BASE_URL=''
+REACT_APP_BASE_URL='help.i.am.broken'


### PR DESCRIPTION
Sorry @manuel-calavera, `REACT_APP_BASE_URL` just needs to be removed.   This is just a hack in the meantime to unbreak the production build.

https://github.com/solana-labs/blockexplorer/blob/master/src/v2/api/socket.js needs a rework such that it doesn't hard code its URL.   The ws/wss URL should come from EndpointConfig.js, and it can change at runtime.