### PR TITLE
feat: total bonded tokens in cluster-info API response

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -498,7 +498,7 @@ async function getClusterInfo() {
   let supply = await connection.getTotalSupply();
   let cluster = await connection.getClusterNodes();
   let voting = await connection.getEpochVoteAccounts();
-  let totalBonded = _.reduce(voting, (a, v) => {
+  let totalStaked = _.reduce(voting, (a, v) => {
     a += (v.stake || 0);
 
     return a;
@@ -520,7 +520,7 @@ async function getClusterInfo() {
     return newc;
   });
 
-  let rest = {feeCalculator, supply, totalBonded, cluster, voting, ts};
+  let rest = {feeCalculator, supply, totalStaked, cluster, voting, ts};
   await setexAsync(
     '!clusterInfo',
     CLUSTER_INFO_CACHE_TIME_SECS,

--- a/api/api.js
+++ b/api/api.js
@@ -498,6 +498,11 @@ async function getClusterInfo() {
   let supply = await connection.getTotalSupply();
   let cluster = await connection.getClusterNodes();
   let voting = await connection.getEpochVoteAccounts();
+  let totalBonded = _.reduce(voting, (a, v) => {
+    a += (v.stake || 0);
+
+    return a;
+  }, 0);
 
   cluster = _.map(cluster, c => {
     let ip = c.gossip.split(':')[0];
@@ -515,7 +520,7 @@ async function getClusterInfo() {
     return newc;
   });
 
-  let rest = {feeCalculator, supply, cluster, voting, ts};
+  let rest = {feeCalculator, supply, totalBonded, cluster, voting, ts};
   await setexAsync(
     '!clusterInfo',
     CLUSTER_INFO_CACHE_TIME_SECS,


### PR DESCRIPTION
problem:

* blockexplorer UI calculates total bonded tokens
* this should be calculated from an API

solution:

* place calculation into the JS API (for now)
