### PR TITLE
fix: correctly map commision field to %

### DIFF
--- a/src/v2/components/Validators/Detail/index.jsx
+++ b/src/v2/components/Validators/Detail/index.jsx
@@ -133,7 +133,7 @@ const ValidatorsDetail = ({match}: {match: Match}) => {
     {
       label: 'commission',
       hint: '',
-      value: `${commission}%`,
+      value: `${(100 * (commission / 0xff)).toFixed(3)}%`,
     },
     {
       label: 'details',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1281082/62475595-31165e80-b75a-11e9-832d-7e89f687d6f6.png)

@sunnygleason / @manuel-calavera - not sure if you guys rather push this logic down a layer into the store or even API server though, as this calculation may surface elsewhere in the UI too?