### PR TITLE
feat: more canonical data from API

### DIFF
--- a/src/v2/components/Dashboard/NetworkOverview/StatCards/index.jsx
+++ b/src/v2/components/Dashboard/NetworkOverview/StatCards/index.jsx
@@ -12,17 +12,18 @@ import Socket from 'v2/stores/socket';
 
 import Loader from '../../Loader';
 import useStyles from './styles';
+import {size} from 'lodash';
 
 const StatCards = () => {
   const {globalStats} = OverviewStore;
-  const {cluster} = NodesStore;
+  const {network} = NodesStore;
   const {isLoading} = Socket;
   const classes = useStyles();
 
   const cards = [
     {
       title: 'Node Count',
-      value: cluster.nodes.length,
+      value: size(network),
     },
     {
       title: 'Block Height',

--- a/src/v2/components/TourDeSol/Cards/index.jsx
+++ b/src/v2/components/TourDeSol/Cards/index.jsx
@@ -14,7 +14,6 @@ const Cards = ({
 }) => {
   const classes = useStyles();
   const {
-    network,
     validators,
     inactiveValidators,
     supply,

--- a/src/v2/components/TourDeSol/Cards/index.jsx
+++ b/src/v2/components/TourDeSol/Cards/index.jsx
@@ -14,10 +14,12 @@ const Cards = ({
 }) => {
   const classes = useStyles();
   const {
-    cluster,
+    network,
     validators,
     inactiveValidators,
-    totalStakedTokens,
+    supply,
+    totalStaked,
+    networkInflationRate,
   } = NodesStore;
 
   const cards = [
@@ -41,19 +43,19 @@ const Cards = ({
     },
     {
       title: 'Total SOL In Circulation',
-      value: (cluster.supply / Math.pow(2, 34)).toFixed(2),
+      value: (supply / Math.pow(2, 34)).toFixed(2),
       changes: '',
       period: 'since yesterday',
     },
     {
-      title: 'Total Staked Tokens',
-      value: totalStakedTokens,
+      title: 'Total Staked SOL',
+      value: totalStaked,
       changes: '',
       period: 'since yesterday',
     },
     {
       title: 'Current Network Inflation Rate',
-      value: (cluster.networkInflationRate * 100.0).toFixed(3) + '%',
+      value: (networkInflationRate * 100.0).toFixed(3) + '%',
       changes: '',
       period: 'since yesterday',
     },

--- a/src/v2/components/TourDeSol/Table/index.jsx
+++ b/src/v2/components/TourDeSol/Table/index.jsx
@@ -32,7 +32,7 @@ const ValidatorsTable = ({separate}: {separate: boolean}) => {
 
   const renderRow = row => {
     const uptime = getUptime(row);
-    const {identity = {}, nodePubkey, stake} = row;
+    const {identity = {}, nodePubkey, activatedStake} = row;
     return (
       <TableRow hover key={nodePubkey}>
         <TableCell>1</TableCell>
@@ -42,14 +42,14 @@ const ValidatorsTable = ({separate}: {separate: boolean}) => {
             <div>{identity.name || nodePubkey}</div>
           </Link>
         </TableCell>
-        <TableCell>{(stake * LAMPORT_SOL_RATIO).toFixed(8)}</TableCell>
+        <TableCell>{(activatedStake * LAMPORT_SOL_RATIO).toFixed(8)}</TableCell>
         <TableCell>{uptime}%</TableCell>
       </TableRow>
     );
   };
   const renderCard = card => {
     const uptime = getUptime(card);
-    const {identity = {}, nodePubkey, stake} = card;
+    const {identity = {}, nodePubkey, activatedStake} = card;
     return (
       <div
         className={cn(classes.card, separate && classes.cardVertical)}
@@ -62,7 +62,7 @@ const ValidatorsTable = ({separate}: {separate: boolean}) => {
         <Grid container>
           <Grid item xs={4} zeroMinWidth>
             <div className={classes.cardTitle}>Stake</div>
-            <div>{(stake * LAMPORT_SOL_RATIO).toFixed(4)} </div>
+            <div>{(activatedStake * LAMPORT_SOL_RATIO).toFixed(4)} </div>
           </Grid>
           <Grid item xs={4} zeroMinWidth>
             <div className={classes.cardTitle}>Uptime</div>

--- a/src/v2/components/TourDeSol/index.jsx
+++ b/src/v2/components/TourDeSol/index.jsx
@@ -64,7 +64,7 @@ const TourDeSol = () => {
 
     if (isActive) {
       return (
-        <li className={cn(classes.stage, classes.stageActive)}>
+        <li className={cn(classes.stage, classes.stageActive)} key={i}>
           <div>
             {stage.title} (LIVE!)
             <img src={iconRight} width={47} height={13} alt="" />
@@ -73,7 +73,7 @@ const TourDeSol = () => {
       );
     } else if (isFinished) {
       return (
-        <li className={classes.stage}>
+        <li className={classes.stage} key={i}>
           <div>
             {stage.title}
             <br />
@@ -83,7 +83,7 @@ const TourDeSol = () => {
       );
     } else {
       return (
-        <li className={classes.stage}>
+        <li className={classes.stage} key={i}>
           <div>
             {stage.title}
             <br />

--- a/src/v2/components/Validators/All/index.jsx
+++ b/src/v2/components/Validators/All/index.jsx
@@ -8,12 +8,14 @@ import ValidatorsTable from '../Table';
 import useStyles from './styles';
 
 const ValidatorsAll = () => {
-  const {validators} = NodesStore;
+  const {validators, inactiveValidators} = NodesStore;
   const classes = useStyles();
   return (
     <Container>
       <SectionHeader title="Validators">
-        <div className={classes.total}>{validators.length}</div>
+        <div className={classes.total}>
+          {validators.length + inactiveValidators.length}
+        </div>
       </SectionHeader>
       <ValidatorsTable separate />
     </Container>

--- a/src/v2/components/Validators/Detail/index.jsx
+++ b/src/v2/components/Validators/Detail/index.jsx
@@ -35,7 +35,7 @@ const mapStyles = {
 };
 
 const ValidatorsDetail = ({match}: {match: Match}) => {
-  const {validators} = NodesStore;
+  const {validators, inactiveValidators} = NodesStore;
   const {globalStats} = OverviewStore;
 
   const classes = useStyles();
@@ -47,13 +47,15 @@ const ValidatorsDetail = ({match}: {match: Match}) => {
     Mixpanel.track(`Clicked Validator ${params.id}`);
   }, [params.id]);
 
-  const node = find({nodePubkey: params.id})(validators);
+  let node =
+    find({nodePubkey: params.id})(validators) ||
+    find({nodePubkey: params.id})(inactiveValidators);
 
   if (!node) {
     return <div>Loading...</div>;
   }
 
-  const {nodePubkey, gossip, stake, commission, identity = {}} = node;
+  const {nodePubkey, gossip, activatedStake, commission, identity = {}} = node;
 
   const renderMarker = () => (
     <Marker
@@ -90,7 +92,7 @@ const ValidatorsDetail = ({match}: {match: Match}) => {
     {
       label: 'Voting power',
       hint: '',
-      value: (stake * LAMPORT_SOL_RATIO).toFixed(8),
+      value: (activatedStake * LAMPORT_SOL_RATIO).toFixed(8),
     },
     {
       label: 'Website',
@@ -231,7 +233,7 @@ const ValidatorsDetail = ({match}: {match: Match}) => {
                   ))
                 }
               </Geographies>
-              <Markers>{renderMarker()}</Markers>
+              <Markers>{node.coordinates && renderMarker()}</Markers>
             </ZoomableGroup>
           </ComposableMap>
         </div>

--- a/src/v2/components/Validators/Table/index.jsx
+++ b/src/v2/components/Validators/Table/index.jsx
@@ -30,7 +30,7 @@ const ValidatorsTable = ({separate}: {separate: boolean}) => {
   const {validators, inactiveValidators} = NodesStore;
   const renderRow = row => {
     const uptime = row.uptime && getUptime(row);
-    const {identity = {}, nodePubkey, stake, commission} = row;
+    const {identity = {}, nodePubkey, activatedStake, commission} = row;
     return (
       <TableRow hover key={nodePubkey}>
         <TableCell align="center">
@@ -40,7 +40,9 @@ const ValidatorsTable = ({separate}: {separate: boolean}) => {
           </Link>
         </TableCell>
         <TableCell>
-          {(stake && (stake * LAMPORT_SOL_RATIO).toFixed(8)) || 'N/A'}
+          {(activatedStake &&
+            (activatedStake * LAMPORT_SOL_RATIO).toFixed(8)) ||
+            'N/A'}
         </TableCell>
         <TableCell>{commission || 'N/A'}</TableCell>
         <TableCell>{(uptime && uptime + '%') || 'Unavailable'}</TableCell>
@@ -49,7 +51,7 @@ const ValidatorsTable = ({separate}: {separate: boolean}) => {
   };
   const renderCard = card => {
     const uptime = card.uptime && getUptime(card);
-    const {identity = {}, nodePubkey, stake, commission} = card;
+    const {identity = {}, nodePubkey, activatedStake, commission} = card;
     return (
       <div
         className={cn(classes.card, separate && classes.cardVertical)}
@@ -63,7 +65,9 @@ const ValidatorsTable = ({separate}: {separate: boolean}) => {
           <Grid item xs={4} zeroMinWidth>
             <div className={classes.cardTitle}>Stake</div>
             <div>
-              {(stake && (stake * LAMPORT_SOL_RATIO).toFixed(4)) || 'N/A'}
+              {(activatedStake &&
+                (activatedStake * LAMPORT_SOL_RATIO).toFixed(4)) ||
+                'N/A'}
             </div>
           </Grid>
           <Grid item xs={4} zeroMinWidth>
@@ -83,7 +87,9 @@ const ValidatorsTable = ({separate}: {separate: boolean}) => {
       {!separate && (
         <div className={classes.header}>
           <Typography>Validators</Typography>
-          <Typography variant="h5">{validators.length}</Typography>
+          <Typography variant="h5">
+            {validators.length + inactiveValidators.length}
+          </Typography>
 
           <Link to="/validators/all" className={classes.link}>
             See all &gt;

--- a/src/v2/components/Validators/index.jsx
+++ b/src/v2/components/Validators/index.jsx
@@ -15,7 +15,7 @@ import useStyles from './styles';
 
 const Validators = () => {
   const classes = useStyles();
-  const {cluster, validators, fetchClusterInfo, totalStakedTokens} = NodesStore;
+  const {supply, validators, fetchClusterInfo, totalStaked} = NodesStore;
   useEffect(() => {
     fetchClusterInfo();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -23,13 +23,13 @@ const Validators = () => {
   const cards = [
     {
       title: 'Total Circulating SOL',
-      value: (cluster.supply / Math.pow(2, 34)).toFixed(2),
+      value: (supply / Math.pow(2, 34)).toFixed(2),
       changes: '',
       period: 'since yesterday',
     },
     {
-      title: 'Total Staked Tokens',
-      value: totalStakedTokens,
+      title: 'Total Staked SOL',
+      value: totalStaked,
       changes: '',
       period: 'since yesterday',
     },

--- a/src/v2/stores/nodes.js
+++ b/src/v2/stores/nodes.js
@@ -8,22 +8,22 @@ class Store {
   };
   clusterChanges = {};
 
-  constructor() {
-    // observe(this, 'network', ({oldValue, newValue}) => {
-    //   if (!keys(oldValue).length) {
-    //     return;
-    //   }
-    //   this.clusterChanges = compose(
-    //     mapValues.convert({cap: false})((value, key) => {
-    //       if (eq('nodes', key)) {
-    //         return calcChanges(oldValue[key].length, value.length);
-    //       }
-    //       return calcChanges(oldValue[key], value);
-    //     }),
-    //     pick(['nodes', 'supply']),
-    //   )(newValue);
-    // });
-  }
+  // constructor() {
+  //   observe(this, 'network', ({oldValue, newValue}) => {
+  //     if (!keys(oldValue).length) {
+  //       return;
+  //     }
+  //     this.clusterChanges = compose(
+  //       mapValues.convert({cap: false})((value, key) => {
+  //         if (eq('nodes', key)) {
+  //           return calcChanges(oldValue[key].length, value.length);
+  //         }
+  //         return calcChanges(oldValue[key], value);
+  //       }),
+  //       pick(['nodes', 'supply']),
+  //     )(newValue);
+  //   });
+  // }
 
   updateClusterInfo = data => {
     data = JSON.parse(data);

--- a/src/v2/stores/nodes.js
+++ b/src/v2/stores/nodes.js
@@ -1,96 +1,80 @@
-import {
-  sumBy,
-  eq,
-  get,
-  compose,
-  keys,
-  filter,
-  map,
-  mapValues,
-  pick,
-  merge,
-  find,
-} from 'lodash/fp';
-import {action, computed, decorate, observable, observe, flow} from 'mobx';
-import {parseClusterInfo} from 'v2/utils/parseMessage';
+import {filter, map} from 'lodash/fp';
+import {action, computed, decorate, observable, flow} from 'mobx';
 import * as API from 'v2/api/stats';
-import calcChanges from 'v2/utils/calcChanges';
 
 class Store {
   cluster = {
-    nodes: [],
-    votingNow: [],
-    votingAll: [],
+    network: {},
   };
   clusterChanges = {};
 
   constructor() {
-    observe(this, 'cluster', ({oldValue, newValue}) => {
-      if (!keys(oldValue).length) {
-        return;
-      }
-      this.clusterChanges = compose(
-        mapValues.convert({cap: false})((value, key) => {
-          if (eq('nodes', key)) {
-            return calcChanges(oldValue[key].length, value.length);
-          }
-          return calcChanges(oldValue[key], value);
-        }),
-        pick(['nodes', 'supply']),
-      )(newValue);
-    });
+    // observe(this, 'network', ({oldValue, newValue}) => {
+    //   if (!keys(oldValue).length) {
+    //     return;
+    //   }
+    //   this.clusterChanges = compose(
+    //     mapValues.convert({cap: false})((value, key) => {
+    //       if (eq('nodes', key)) {
+    //         return calcChanges(oldValue[key].length, value.length);
+    //       }
+    //       return calcChanges(oldValue[key], value);
+    //     }),
+    //     pick(['nodes', 'supply']),
+    //   )(newValue);
+    // });
   }
 
   updateClusterInfo = data => {
-    this.cluster = merge(this.cluster, parseClusterInfo(data));
+    data = JSON.parse(data);
+    this.network = data.network || {};
+    this.totalStaked = data.totalStaked;
+    this.supply = data.supply;
+    this.networkInflationRate = data.networkInflationRate;
   };
 
   fetchClusterInfo = flow(function*() {
     const res = yield API.getClusterInfo();
-    this.cluster = merge(this.cluster, res.data);
+    const data = res.data;
+    this.network = data.network;
+    this.totalStaked = data.totalStaked;
+    this.supply = data.supply;
+    this.networkInflationRate = data.networkInflationRate;
   });
 
   get mapMarkers() {
-    return map(({pubkey: name, gossip, lat, lng}) => ({
+    let validators = filter(node => node.what === 'Validator')(this.network);
+
+    validators = map(({nodePubkey: name, tpu: gossip, coordinates}) => ({
       name,
       gossip,
-      coordinates: [lng, lat],
-    }))(this.cluster.nodes);
+      coordinates,
+    }))(validators);
+
+    return validators;
   }
 
   get validators() {
-    return map(vote => {
-      const cluster =
-        find({pubkey: vote.nodePubkey})(this.cluster.cluster) || {};
-      const {lng = 0, lat = 0, gossip} = cluster;
-      return {
-        ...vote,
-        coordinates: [lng, lat],
-        gossip,
-        uptime: find({votePubkey: vote.votePubkey})(this.cluster.uptime),
-        identity: find({pubkey: vote.nodePubkey})(this.cluster.identities),
-      };
-    })(this.cluster.votingNow);
+    let active = filter(
+      node => node.what === 'Validator' && node.activatedStake,
+    )(this.network);
+
+    return active;
   }
 
   get inactiveValidators() {
     let inactive = filter(
-      vote => !find({pubkey: vote.nodePubkey})(this.cluster.cluster),
-    )(this.cluster.votingAll);
+      node => node.what === 'Validator' && !node.activatedStake,
+    )(this.network);
 
     return inactive;
-  }
-
-  get totalStakedTokens() {
-    return compose(
-      sumBy('stake'),
-      get('votingNow'),
-    )(this.cluster);
   }
 }
 
 decorate(Store, {
-  cluster: observable,
+  network: observable,
+  supply: observable,
+  stakedTokens: observable,
   updateClusterInfo: action.bound,
   mapMarkers: computed,
   validators: computed,

--- a/src/v2/utils/parseMessage.js
+++ b/src/v2/utils/parseMessage.js
@@ -1,4 +1,4 @@
-import {find, compose, split, map} from 'lodash/fp';
+import {compose, split, map} from 'lodash/fp';
 
 export function parseTransaction(message) {
   const [h, l, s, dt, entry_id, id, inst] = split('#')(message);
@@ -42,25 +42,12 @@ export function parseBlock(message) {
 }
 
 export function parseClusterInfo(data) {
-  const {
-    votingNow,
-    votingAll,
-    cluster: gossip,
-    supply,
-    feeCalculator,
-    identities,
-  } = JSON.parse(data);
-
-  const nodes = map(g => ({
-    ...g,
-    voteAccount: find({nodePubkey: g.pubKey})(votingNow),
-  }))(gossip);
+  const {network, supply, totalStaked, feeCalculator} = JSON.parse(data);
 
   return {
-    nodes,
+    network,
     supply,
+    totalStaked,
     feeCalculator,
-    identities,
-    votingAll,
   };
 }


### PR DESCRIPTION
problem:

* the validators list is more confusing than necessary because there isn't a "real" API for it
* we currently have to do a complicated "merge" between cluster gossip, epoch vote info and all vote account info

solution:

* we'd like this logic to move closer to the fullnode
* currently, we'll settle for moving it into the JS api

Upcoming PR: migrating validator display to this data model
