### PR TITLE
feat: remove command-line solana dep, use web3js for uptime instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "base-58": "^0.0.1",
     "classnames": "^2.2.6",
-    "command-exists": "^1.2.8",
     "copy-to-clipboard": "^3.2.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4446,11 +4446,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-command-exists@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
-  integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
-
 commander@2, commander@^2.11.0, commander@^2.12.2, commander@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"


### PR DESCRIPTION
Problem:

* uptime *used* to require solana CLI and way too much forking

Solution:

* use the shiny web3js functionality instead
